### PR TITLE
Add CAD viewer section for portfolio models

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2576,3 +2576,131 @@ body.dark-mode .timeline-content p:last-child {
         font-size: 1.02rem;
     }
 }
+
+/* CAD Section */
+.cad-section {
+    position: relative;
+}
+
+.cad-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.cad-copy {
+    background: linear-gradient(135deg, rgba(231, 76, 60, 0.08), rgba(9, 132, 227, 0.08));
+    border: 1px solid rgba(231, 76, 60, 0.18);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.06);
+}
+
+body.dark-mode .cad-copy {
+    background: linear-gradient(135deg, rgba(9, 132, 227, 0.12), rgba(231, 76, 60, 0.08));
+    border-color: rgba(9, 132, 227, 0.22);
+}
+
+.cad-intro {
+    font-size: 1.05rem;
+    margin-bottom: 1rem;
+}
+
+.cad-details {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.cad-details li {
+    display: flex;
+    gap: 0.6rem;
+    align-items: baseline;
+    line-height: 1.5;
+}
+
+.cad-label {
+    font-weight: 600;
+    white-space: nowrap;
+    color: var(--primary-color);
+}
+
+body.dark-mode .cad-label {
+    color: var(--accent-color);
+}
+
+.cad-tip {
+    font-size: 0.95rem;
+    opacity: 0.85;
+}
+
+.cad-viewer {
+    position: relative;
+    background: radial-gradient(circle at 30% 20%, rgba(231, 76, 60, 0.25), transparent 35%), radial-gradient(circle at 70% 40%, rgba(9, 132, 227, 0.25), transparent 35%), linear-gradient(140deg, #0f131a 0%, #0b1018 100%);
+    border-radius: 18px;
+    overflow: hidden;
+    min-height: 420px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 25px 80px rgba(0, 0, 0, 0.25);
+}
+
+body.light-mode .cad-viewer {
+    border-color: rgba(0, 0, 0, 0.06);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12);
+}
+
+.cad-glow {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.08), transparent 45%);
+    pointer-events: none;
+    z-index: 1;
+}
+
+#cad-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+}
+
+.cad-status {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.55);
+    color: #e8f3ff;
+    font-size: 0.95rem;
+    backdrop-filter: blur(6px);
+    z-index: 3;
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cad-status.loaded {
+    background: rgba(14, 161, 125, 0.75);
+    color: #e7fff7;
+    border-color: rgba(14, 161, 125, 0.5);
+}
+
+@media (max-width: 768px) {
+    .cad-viewer {
+        min-height: 360px;
+    }
+
+    .cad-status {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.4rem;
+    }
+}

--- a/assets/js/cad-viewer.js
+++ b/assets/js/cad-viewer.js
@@ -13,25 +13,25 @@
     {
       check: () => window.THREE,
       urls: [
-        "assets/js/vendor/three/three.min.js",
         "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/three.min.js",
         "https://unpkg.com/three@0.160.0/build/three.min.js",
+        "assets/js/vendor/three/three.min.js",
       ],
     },
     {
       check: () => window.THREE && THREE.GLTFLoader,
       urls: [
-        "assets/js/vendor/three/GLTFLoader.js",
         "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/examples/js/loaders/GLTFLoader.js",
         "https://unpkg.com/three@0.160.0/examples/js/loaders/GLTFLoader.js",
+        "assets/js/vendor/three/GLTFLoader.js",
       ],
     },
     {
       check: () => window.THREE && THREE.OrbitControls,
       urls: [
-        "assets/js/vendor/three/OrbitControls.js",
         "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/examples/js/controls/OrbitControls.js",
         "https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js",
+        "assets/js/vendor/three/OrbitControls.js",
       ],
     },
   ];

--- a/assets/js/cad-viewer.js
+++ b/assets/js/cad-viewer.js
@@ -2,23 +2,48 @@
   const canvas = document.getElementById("cad-canvas");
   const statusEl = document.getElementById("cad-status");
   const viewer = canvas?.parentElement;
-  const MODEL_PATH = "/assets/models/cad-portfolio.glb";
+  const MODEL_PATH = "assets/models/cad-portfolio.glb";
+  const isFileProtocol = window.location.protocol === "file:";
 
   if (!canvas || !viewer) {
     return;
   }
 
-  const CDN_BASE = "https://unpkg.com/three@0.160.0";
-  const FALLBACKS = [
-    { check: () => window.THREE, url: `${CDN_BASE}/build/three.min.js` },
-    { check: () => window.THREE && THREE.GLTFLoader, url: `${CDN_BASE}/examples/js/loaders/GLTFLoader.js` },
-    { check: () => window.THREE && THREE.OrbitControls, url: `${CDN_BASE}/examples/js/controls/OrbitControls.js` },
+  const sourceSets = [
+    {
+      check: () => window.THREE,
+      urls: [
+        "assets/js/vendor/three/three.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/three.min.js",
+        "https://unpkg.com/three@0.160.0/build/three.min.js",
+      ],
+    },
+    {
+      check: () => window.THREE && THREE.GLTFLoader,
+      urls: [
+        "assets/js/vendor/three/GLTFLoader.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/examples/js/loaders/GLTFLoader.js",
+        "https://unpkg.com/three@0.160.0/examples/js/loaders/GLTFLoader.js",
+      ],
+    },
+    {
+      check: () => window.THREE && THREE.OrbitControls,
+      urls: [
+        "assets/js/vendor/three/OrbitControls.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/examples/js/controls/OrbitControls.js",
+        "https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js",
+      ],
+    },
   ];
 
   const loadScript = (url) =>
     new Promise((resolve, reject) => {
-      const existing = document.querySelector(`script[src=\"${url}\"]`);
+      const existing = document.querySelector(`script[src="${url}"]`);
       if (existing) {
+        if (existing.dataset.loaded === "true") {
+          resolve();
+          return;
+        }
         existing.addEventListener("load", () => resolve());
         existing.addEventListener("error", (e) => reject(e));
         return;
@@ -26,15 +51,31 @@
       const script = document.createElement("script");
       script.src = url;
       script.async = true;
-      script.onload = () => resolve();
+      script.onload = () => {
+        script.dataset.loaded = "true";
+        resolve();
+      };
       script.onerror = (e) => reject(e);
       document.head.appendChild(script);
     });
 
   const ensureDependencies = async () => {
-    for (const { check, url } of FALLBACKS) {
-      if (!check()) {
-        await loadScript(url);
+    for (const { check, urls } of sourceSets) {
+      if (check()) continue;
+      let loaded = false;
+      for (const url of urls) {
+        try {
+          await loadScript(url);
+          if (check()) {
+            loaded = true;
+            break;
+          }
+        } catch (e) {
+          // try next source
+        }
+      }
+      if (!loaded && !check()) {
+        return false;
       }
     }
     return window.THREE && THREE.GLTFLoader && THREE.OrbitControls;
@@ -44,7 +85,10 @@
     const ready = await ensureDependencies().catch(() => false);
     if (!ready) {
       if (statusEl) {
-        statusEl.textContent = "Three.js viewer dependencies failed to load. Check your connection and reload.";
+        const reason = isFileProtocol
+          ? "Serve the site via http(s) (e.g., `python -m http.server`) so scripts can load."
+          : "Check ad-blockers/network settings or host the Three.js files locally in assets/js/vendor/three/.";
+        statusEl.textContent = `Three.js viewer dependencies failed to load. ${reason}`;
       }
       return;
     }

--- a/assets/js/cad-viewer.js
+++ b/assets/js/cad-viewer.js
@@ -8,158 +8,195 @@
     return;
   }
 
-  if (!window.THREE || !THREE.GLTFLoader || !THREE.OrbitControls) {
-    if (statusEl) {
-      statusEl.textContent = "Three.js viewer dependencies failed to load.";
+  const CDN_BASE = "https://unpkg.com/three@0.160.0";
+  const FALLBACKS = [
+    { check: () => window.THREE, url: `${CDN_BASE}/build/three.min.js` },
+    { check: () => window.THREE && THREE.GLTFLoader, url: `${CDN_BASE}/examples/js/loaders/GLTFLoader.js` },
+    { check: () => window.THREE && THREE.OrbitControls, url: `${CDN_BASE}/examples/js/controls/OrbitControls.js` },
+  ];
+
+  const loadScript = (url) =>
+    new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[src=\"${url}\"]`);
+      if (existing) {
+        existing.addEventListener("load", () => resolve());
+        existing.addEventListener("error", (e) => reject(e));
+        return;
+      }
+      const script = document.createElement("script");
+      script.src = url;
+      script.async = true;
+      script.onload = () => resolve();
+      script.onerror = (e) => reject(e);
+      document.head.appendChild(script);
+    });
+
+  const ensureDependencies = async () => {
+    for (const { check, url } of FALLBACKS) {
+      if (!check()) {
+        await loadScript(url);
+      }
     }
-    return;
-  }
-
-  const renderer = new THREE.WebGLRenderer({
-    canvas,
-    antialias: true,
-    alpha: true,
-  });
-  renderer.outputEncoding = THREE.sRGBEncoding;
-  renderer.shadowMap.enabled = true;
-  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-
-  const scene = new THREE.Scene();
-  scene.fog = new THREE.FogExp2(0x0c1016, 0.065);
-
-  const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
-  camera.position.set(0.5, 0.35, 2.6);
-  scene.add(camera);
-
-  const controls = new THREE.OrbitControls(camera, canvas);
-  controls.enableDamping = true;
-  controls.enablePan = false;
-  controls.minDistance = 1.1;
-  controls.maxDistance = 4;
-  controls.target.set(0, 0.25, 0);
-
-  const hemi = new THREE.HemisphereLight(0x9fd7ff, 0x0c1016, 0.45);
-  scene.add(hemi);
-
-  const keyLight = new THREE.DirectionalLight(0xffffff, 1.4);
-  keyLight.position.set(3, 5, 3);
-  keyLight.castShadow = true;
-  scene.add(keyLight);
-
-  const rimLight = new THREE.DirectionalLight(0x66aaff, 0.65);
-  rimLight.position.set(-3, 2, -2);
-  scene.add(rimLight);
-
-  const bounce = new THREE.PointLight(0xff7b4a, 0.6, 10);
-  bounce.position.set(0.5, 0.3, 1.5);
-  scene.add(bounce);
-
-  const stageGeometry = new THREE.CircleGeometry(1.8, 80);
-  const stageMaterial = new THREE.MeshStandardMaterial({
-    color: 0x0f131a,
-    roughness: 0.9,
-    metalness: 0.05,
-    transparent: true,
-    opacity: 0.65,
-  });
-  const stage = new THREE.Mesh(stageGeometry, stageMaterial);
-  stage.rotation.x = -Math.PI / 2;
-  stage.receiveShadow = true;
-  scene.add(stage);
-
-  const resize = () => {
-    const { clientWidth, clientHeight } = viewer;
-    if (!clientWidth || !clientHeight) return;
-
-    const height = Math.max(clientHeight, 360);
-    renderer.setSize(clientWidth, height, false);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-
-    camera.aspect = clientWidth / height;
-    camera.updateProjectionMatrix();
+    return window.THREE && THREE.GLTFLoader && THREE.OrbitControls;
   };
 
-  window.addEventListener("resize", resize);
-  resize();
-
-  let model;
-  let idleSpin = 0;
-  let scrollRotation = 0;
-
-  const loader = new THREE.GLTFLoader();
-  loader.load(
-    MODEL_PATH,
-    (gltf) => {
-      model = gltf.scene;
-      model.traverse((child) => {
-        if (child.isMesh) {
-          child.castShadow = true;
-          child.receiveShadow = true;
-          const materials = Array.isArray(child.material) ? child.material : [child.material];
-          materials.forEach((material) => {
-            if (!material) return;
-            if (!material.map && material.metalness !== undefined && material.roughness !== undefined) {
-              material.metalness = 0.15;
-              material.roughness = 0.28;
-            }
-          });
-        }
-      });
-
-      centerAndFitModel(model);
-      scene.add(model);
-
+  const init = async () => {
+    const ready = await ensureDependencies().catch(() => false);
+    if (!ready) {
       if (statusEl) {
-        statusEl.textContent = "Scroll to rotate • Drag to orbit";
-        statusEl.classList.add("loaded");
+        statusEl.textContent = "Three.js viewer dependencies failed to load. Check your connection and reload.";
       }
-    },
-    undefined,
-    () => {
-      if (statusEl) {
-        statusEl.textContent = "Model not found. Add cad-portfolio.glb to assets/models.";
-      }
-    },
-  );
-
-  function centerAndFitModel(object) {
-    const box = new THREE.Box3().setFromObject(object);
-    const size = box.getSize(new THREE.Vector3());
-    const maxDim = Math.max(size.x, size.y, size.z);
-    const scale = 1.4 / maxDim;
-    object.scale.setScalar(scale);
-
-    box.setFromObject(object);
-    const center = box.getCenter(new THREE.Vector3());
-    object.position.sub(center);
-    object.position.y -= size.y * scale * 0.2;
-  }
-
-  function updateScrollRotation() {
-    const scrollY = window.scrollY || window.pageYOffset;
-    scrollRotation = scrollY * 0.002;
-  }
-
-  window.addEventListener("scroll", updateScrollRotation);
-  updateScrollRotation();
-
-  const clock = new THREE.Clock();
-
-  function animate() {
-    requestAnimationFrame(animate);
-
-    const delta = clock.getDelta();
-    idleSpin += delta * 0.45;
-
-    if (model) {
-      const targetRotation = scrollRotation + idleSpin * 0.2;
-      model.rotation.y = THREE.MathUtils.lerp(model.rotation.y, targetRotation, 0.08);
-      model.rotation.x = THREE.MathUtils.lerp(model.rotation.x, 0, 0.1);
+      return;
     }
 
-    controls.update();
-    renderer.render(scene, camera);
-  }
+    const renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: true,
+      alpha: true,
+    });
+    renderer.outputEncoding = THREE.sRGBEncoding;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-  animate();
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x0c1016, 0.065);
+
+    const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
+    camera.position.set(0.5, 0.35, 2.6);
+    scene.add(camera);
+
+    const controls = new THREE.OrbitControls(camera, canvas);
+    controls.enableDamping = true;
+    controls.enablePan = false;
+    controls.minDistance = 1.1;
+    controls.maxDistance = 4;
+    controls.target.set(0, 0.25, 0);
+
+    const hemi = new THREE.HemisphereLight(0x9fd7ff, 0x0c1016, 0.45);
+    scene.add(hemi);
+
+    const keyLight = new THREE.DirectionalLight(0xffffff, 1.4);
+    keyLight.position.set(3, 5, 3);
+    keyLight.castShadow = true;
+    scene.add(keyLight);
+
+    const rimLight = new THREE.DirectionalLight(0x66aaff, 0.65);
+    rimLight.position.set(-3, 2, -2);
+    scene.add(rimLight);
+
+    const bounce = new THREE.PointLight(0xff7b4a, 0.6, 10);
+    bounce.position.set(0.5, 0.3, 1.5);
+    scene.add(bounce);
+
+    const stageGeometry = new THREE.CircleGeometry(1.8, 80);
+    const stageMaterial = new THREE.MeshStandardMaterial({
+      color: 0x0f131a,
+      roughness: 0.9,
+      metalness: 0.05,
+      transparent: true,
+      opacity: 0.65,
+    });
+    const stage = new THREE.Mesh(stageGeometry, stageMaterial);
+    stage.rotation.x = -Math.PI / 2;
+    stage.receiveShadow = true;
+    scene.add(stage);
+
+    const resize = () => {
+      const { clientWidth, clientHeight } = viewer;
+      if (!clientWidth || !clientHeight) return;
+
+      const height = Math.max(clientHeight, 360);
+      renderer.setSize(clientWidth, height, false);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+      camera.aspect = clientWidth / height;
+      camera.updateProjectionMatrix();
+    };
+
+    window.addEventListener("resize", resize);
+    resize();
+
+    let model;
+    let idleSpin = 0;
+    let scrollRotation = 0;
+
+    const loader = new THREE.GLTFLoader();
+    loader.load(
+      MODEL_PATH,
+      (gltf) => {
+        model = gltf.scene;
+        model.traverse((child) => {
+          if (child.isMesh) {
+            child.castShadow = true;
+            child.receiveShadow = true;
+            const materials = Array.isArray(child.material) ? child.material : [child.material];
+            materials.forEach((material) => {
+              if (!material) return;
+              if (!material.map && material.metalness !== undefined && material.roughness !== undefined) {
+                material.metalness = 0.15;
+                material.roughness = 0.28;
+              }
+            });
+          }
+        });
+
+        centerAndFitModel(model);
+        scene.add(model);
+
+        if (statusEl) {
+          statusEl.textContent = "Scroll to rotate • Drag to orbit";
+          statusEl.classList.add("loaded");
+        }
+      },
+      undefined,
+      () => {
+        if (statusEl) {
+          statusEl.textContent = "Model not found. Add cad-portfolio.glb to assets/models.";
+        }
+      },
+    );
+
+    function centerAndFitModel(object) {
+      const box = new THREE.Box3().setFromObject(object);
+      const size = box.getSize(new THREE.Vector3());
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const scale = 1.4 / maxDim;
+      object.scale.setScalar(scale);
+
+      box.setFromObject(object);
+      const center = box.getCenter(new THREE.Vector3());
+      object.position.sub(center);
+      object.position.y -= size.y * scale * 0.2;
+    }
+
+    function updateScrollRotation() {
+      const scrollY = window.scrollY || window.pageYOffset;
+      scrollRotation = scrollY * 0.002;
+    }
+
+    window.addEventListener("scroll", updateScrollRotation);
+    updateScrollRotation();
+
+    const clock = new THREE.Clock();
+
+    function animate() {
+      requestAnimationFrame(animate);
+
+      const delta = clock.getDelta();
+      idleSpin += delta * 0.45;
+
+      if (model) {
+        const targetRotation = scrollRotation + idleSpin * 0.2;
+        model.rotation.y = THREE.MathUtils.lerp(model.rotation.y, targetRotation, 0.08);
+        model.rotation.x = THREE.MathUtils.lerp(model.rotation.x, 0, 0.1);
+      }
+
+      controls.update();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+  };
+
+  init();
 })();

--- a/assets/js/cad-viewer.js
+++ b/assets/js/cad-viewer.js
@@ -1,0 +1,165 @@
+(() => {
+  const canvas = document.getElementById("cad-canvas");
+  const statusEl = document.getElementById("cad-status");
+  const viewer = canvas?.parentElement;
+  const MODEL_PATH = "/assets/models/cad-portfolio.glb";
+
+  if (!canvas || !viewer) {
+    return;
+  }
+
+  if (!window.THREE || !THREE.GLTFLoader || !THREE.OrbitControls) {
+    if (statusEl) {
+      statusEl.textContent = "Three.js viewer dependencies failed to load.";
+    }
+    return;
+  }
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+  });
+  renderer.outputEncoding = THREE.sRGBEncoding;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+  const scene = new THREE.Scene();
+  scene.fog = new THREE.FogExp2(0x0c1016, 0.065);
+
+  const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
+  camera.position.set(0.5, 0.35, 2.6);
+  scene.add(camera);
+
+  const controls = new THREE.OrbitControls(camera, canvas);
+  controls.enableDamping = true;
+  controls.enablePan = false;
+  controls.minDistance = 1.1;
+  controls.maxDistance = 4;
+  controls.target.set(0, 0.25, 0);
+
+  const hemi = new THREE.HemisphereLight(0x9fd7ff, 0x0c1016, 0.45);
+  scene.add(hemi);
+
+  const keyLight = new THREE.DirectionalLight(0xffffff, 1.4);
+  keyLight.position.set(3, 5, 3);
+  keyLight.castShadow = true;
+  scene.add(keyLight);
+
+  const rimLight = new THREE.DirectionalLight(0x66aaff, 0.65);
+  rimLight.position.set(-3, 2, -2);
+  scene.add(rimLight);
+
+  const bounce = new THREE.PointLight(0xff7b4a, 0.6, 10);
+  bounce.position.set(0.5, 0.3, 1.5);
+  scene.add(bounce);
+
+  const stageGeometry = new THREE.CircleGeometry(1.8, 80);
+  const stageMaterial = new THREE.MeshStandardMaterial({
+    color: 0x0f131a,
+    roughness: 0.9,
+    metalness: 0.05,
+    transparent: true,
+    opacity: 0.65,
+  });
+  const stage = new THREE.Mesh(stageGeometry, stageMaterial);
+  stage.rotation.x = -Math.PI / 2;
+  stage.receiveShadow = true;
+  scene.add(stage);
+
+  const resize = () => {
+    const { clientWidth, clientHeight } = viewer;
+    if (!clientWidth || !clientHeight) return;
+
+    const height = Math.max(clientHeight, 360);
+    renderer.setSize(clientWidth, height, false);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    camera.aspect = clientWidth / height;
+    camera.updateProjectionMatrix();
+  };
+
+  window.addEventListener("resize", resize);
+  resize();
+
+  let model;
+  let idleSpin = 0;
+  let scrollRotation = 0;
+
+  const loader = new THREE.GLTFLoader();
+  loader.load(
+    MODEL_PATH,
+    (gltf) => {
+      model = gltf.scene;
+      model.traverse((child) => {
+        if (child.isMesh) {
+          child.castShadow = true;
+          child.receiveShadow = true;
+          const materials = Array.isArray(child.material) ? child.material : [child.material];
+          materials.forEach((material) => {
+            if (!material) return;
+            if (!material.map && material.metalness !== undefined && material.roughness !== undefined) {
+              material.metalness = 0.15;
+              material.roughness = 0.28;
+            }
+          });
+        }
+      });
+
+      centerAndFitModel(model);
+      scene.add(model);
+
+      if (statusEl) {
+        statusEl.textContent = "Scroll to rotate • Drag to orbit";
+        statusEl.classList.add("loaded");
+      }
+    },
+    undefined,
+    () => {
+      if (statusEl) {
+        statusEl.textContent = "Model not found. Add cad-portfolio.glb to assets/models.";
+      }
+    },
+  );
+
+  function centerAndFitModel(object) {
+    const box = new THREE.Box3().setFromObject(object);
+    const size = box.getSize(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const scale = 1.4 / maxDim;
+    object.scale.setScalar(scale);
+
+    box.setFromObject(object);
+    const center = box.getCenter(new THREE.Vector3());
+    object.position.sub(center);
+    object.position.y -= size.y * scale * 0.2;
+  }
+
+  function updateScrollRotation() {
+    const scrollY = window.scrollY || window.pageYOffset;
+    scrollRotation = scrollY * 0.002;
+  }
+
+  window.addEventListener("scroll", updateScrollRotation);
+  updateScrollRotation();
+
+  const clock = new THREE.Clock();
+
+  function animate() {
+    requestAnimationFrame(animate);
+
+    const delta = clock.getDelta();
+    idleSpin += delta * 0.45;
+
+    if (model) {
+      const targetRotation = scrollRotation + idleSpin * 0.2;
+      model.rotation.y = THREE.MathUtils.lerp(model.rotation.y, targetRotation, 0.08);
+      model.rotation.x = THREE.MathUtils.lerp(model.rotation.x, 0, 0.1);
+    }
+
+    controls.update();
+    renderer.render(scene, camera);
+  }
+
+  animate();
+})();

--- a/assets/js/vendor/README.md
+++ b/assets/js/vendor/README.md
@@ -1,0 +1,8 @@
+This folder is for self-hosted Three.js builds if your environment blocks external CDNs.
+
+Place these files (matching Three r160) to load locally instead of the CDN:
+- assets/js/vendor/three/three.min.js
+- assets/js/vendor/three/GLTFLoader.js
+- assets/js/vendor/three/OrbitControls.js
+
+You can download them from https://threejs.org/ or a CDN and drop them here.

--- a/assets/models/README.md
+++ b/assets/models/README.md
@@ -1,0 +1,1 @@
+Place your GLB/GLTF portfolio model in this folder and name it `cad-portfolio.glb` to match the viewer in index.html.

--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/loaders/GLTFLoader.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/controls/OrbitControls.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.fog.min.js"></script>
 
         <script type="application/ld+json">
@@ -120,6 +122,9 @@
                         <a href="#projects"><i class="fas fa-code-branch"></i> Projects & Contributions</a>
                     </li>
                     <li>
+                        <a href="#cad"><i class="fas fa-cube"></i> CAD</a>
+                    </li>
+                    <li>
                         <a href="#experience"><i class="fas fa-briefcase"></i> Experience</a>
                     </li>
                     <li>
@@ -180,6 +185,33 @@
                             <p class="education-points">625 Points</p>
                             <p class="education-subjects">100% in Mathematics, Physics, and Computer Science</p>
                         </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="cad" class="cad-section">
+                <div class="section-header">
+                    <h2><i class="fas fa-cube section-icon"></i> CAD Portfolio</h2>
+                    <div class="section-line"></div>
+                </div>
+
+                <div class="cad-grid">
+                    <div class="cad-copy">
+                        <p class="cad-intro">Drop your GLB/GLTF export here to let visitors orbit and scroll-spin your design with studio lighting.</p>
+                        <ul class="cad-details">
+                            <li><span class="cad-label">Model path:</span> <code>assets/models/cad-portfolio.glb</code></li>
+                            <li><span class="cad-label">Best results:</span> export as glTF/GLB with PBR materials; keep polycount reasonable.</li>
+                            <li><span class="cad-label">Controls:</span> scroll to rotate, drag to orbit, scroll-wheel/pinch to zoom.</li>
+                        </ul>
+                        <p class="cad-tip">
+                            Tip: add an HDRI to <code>assets/env/</code> and swap the path in the viewer script for glossy reflections.
+                        </p>
+                    </div>
+
+                    <div class="cad-viewer">
+                        <div class="cad-glow"></div>
+                        <canvas id="cad-canvas" aria-label="3D CAD viewer"></canvas>
+                        <div id="cad-status" class="cad-status">Place <code>cad-portfolio.glb</code> in <code>assets/models/</code> to load your design.</div>
                     </div>
                 </div>
             </section>
@@ -709,6 +741,7 @@
 
         <!-- Your existing script -->
         <script src="assets/js/script.js"></script>
+        <script src="assets/js/cad-viewer.js"></script>
 
         <!-- Vanta.js Initialization -->
         <script>


### PR DESCRIPTION
## Summary
- add a CAD portfolio section with guidance for dropping a glTF/GLB model at assets/models/cad-portfolio.glb
- style the CAD viewer area with gradient framing and status messaging for load state
- wire up a Three.js viewer with orbit controls, scroll-driven rotation, and a placeholder README in assets/models

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b80d68d8832b8d0e15e52c59352c)